### PR TITLE
fix: JUnit5와 Cucumber 호환 문제 해결을 위한 gradle 의존성 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-java:7.12.1'
     testImplementation 'io.cucumber:cucumber-junit:7.12.1'
     testImplementation 'io.cucumber:cucumber-spring:7.12.1'
+    testImplementation 'org.junit.vintage:junit-vintage-engine'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 😋 작업한 내용

junit.vintage Gradle 의존성 추가

## 🙏 PR Point

- 의존성 추가를 하여 EntryPoint를 통해 Cucumber 테스트 실행이 가능해졌습니다.

## 👍 관련 이슈

- Resolved : #48 
