### PR TITLE
refactor: 로그 파일 생성 설정 변경

### DIFF
--- a/backend/src/main/resources/dev-file-appender.xml
+++ b/backend/src/main/resources/dev-file-appender.xml
@@ -10,7 +10,7 @@
       <pattern>${LOG_PATTERN}</pattern> <!-- 로그 형식 -->
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./backup/dev/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/dev/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>
@@ -29,7 +29,7 @@
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./backup/dev/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/dev/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>
@@ -47,7 +47,7 @@
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./backup/dev/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/dev/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>

--- a/backend/src/main/resources/dev-file-appender.xml
+++ b/backend/src/main/resources/dev-file-appender.xml
@@ -10,7 +10,7 @@
       <pattern>${LOG_PATTERN}</pattern> <!-- 로그 형식 -->
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/dev/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/dev/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -12,7 +12,7 @@
         </root>
     </springProfile>
 
-    <!-- 프로덕션 환경 -->
+    <!-- 개발 환경 -->
     <springProfile name="dev">
         <include resource="dev-file-appender.xml"/>
 
@@ -23,6 +23,7 @@
         </root>
     </springProfile>
 
+    <!-- 프로덕션 환경 -->
     <springProfile name="prod">
         <include resource="prod-file-appender.xml"/>
 

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <configuration>
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
     <property name="LOG_PATTERN"
-      value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+      value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %cyan([%C.%M:%yellow(%L)]) - %msg%n"/>
 
     <!--  프로덕션 외의 환경 -->
     <springProfile name="local, test, default">

--- a/backend/src/main/resources/prod-file-appender.xml
+++ b/backend/src/main/resources/prod-file-appender.xml
@@ -10,7 +10,7 @@
       <pattern>${LOG_PATTERN}</pattern> <!-- 로그 형식 -->
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./backup/prod/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/prod/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>
@@ -29,7 +29,7 @@
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./backup/prod/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/prod/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>
@@ -47,7 +47,7 @@
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./backup/prod/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/prod/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>

--- a/backend/src/main/resources/prod-file-appender.xml
+++ b/backend/src/main/resources/prod-file-appender.xml
@@ -10,7 +10,7 @@
       <pattern>${LOG_PATTERN}</pattern> <!-- 로그 형식 -->
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>./log/prod/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>./log/prod/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>100MB</maxFileSize>
       <maxHistory>30</maxHistory>
       <totalSizeCap>3GB</totalSizeCap>


### PR DESCRIPTION
## 😋 작업한 내용

로그 파일이 날마다 새로 생성되도록 수정했습니다.

## 🙏 PR Point

RollingPolicy 옵션이 용량이 가득 찼을 때만 적용되는 것이고, 시간에 따른 갱신은 알아서 해주는 줄 알았습니다.
그래서 기존에는 `backup/` 디렉토리에서 갱신이 되도록 설정했었는데, 이게 시간에 따라서도 갱신이 되는 것이기 때문에 기존에 로그를 저장하던 `log/`디렉토리에서 갱신이 되도록 설정 수정했습니다.

## 👍 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved : #204 
