### PR TITLE
test: DatabaseCleaner 구현

### DIFF
--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/AcceptanceTest.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/AcceptanceTest.java
@@ -4,14 +4,13 @@ import com.yigongil.backend.BackendApplication;
 import io.cucumber.java.Before;
 import io.cucumber.spring.CucumberContextConfiguration;
 import io.restassured.RestAssured;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 @CucumberContextConfiguration
-@DirtiesContext
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(classes = BackendApplication.class)
 public class AcceptanceTest {
@@ -19,8 +18,13 @@ public class AcceptanceTest {
     @LocalServerPort
     int port;
 
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     @Before
     public void before() {
         RestAssured.port = port;
+        databaseCleaner.clean();
     }
 }

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/AcceptanceTest.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/AcceptanceTest.java
@@ -18,7 +18,6 @@ public class AcceptanceTest {
     @LocalServerPort
     int port;
 
-
     @Autowired
     private DatabaseCleaner databaseCleaner;
 

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
@@ -1,0 +1,53 @@
+package com.yigongil.backend.acceptance.steps;
+
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("test")
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tables;
+
+    @Override
+    public void afterPropertiesSet() {
+        this.tables = entityManager.getMetamodel().getEntities().stream()
+                                   .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                                   .map(EntityType::getName)
+                                   .map(this::toSnake)
+                                   .toList();
+    }
+
+    private String toSnake(String camel) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < camel.length(); i++) {
+            char c = camel.charAt(i);
+            if (c >= 'A' && c <= 'Z' && i != 0) {
+                sb.append('_');
+            }
+            sb.append(c);
+        }
+        return sb.toString().toLowerCase();
+    }
+
+    @Transactional
+    public void clean() {
+        entityManager.createNativeQuery("set foreign_key_checks = 0").executeUpdate();
+
+        for (String table : tables) {
+            entityManager.createNativeQuery("truncate table " + table).executeUpdate();
+        }
+
+        entityManager.createNativeQuery("set foreign_key_checks = 1").executeUpdate();
+    }
+}

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
@@ -1,25 +1,25 @@
 package com.yigongil.backend.acceptance.steps;
 
 import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.metamodel.EntityType;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Profile("test")
 @Component
-public class DatabaseCleaner implements InitializingBean {
+public class DatabaseCleaner {
 
     @PersistenceContext
     private EntityManager entityManager;
 
     private List<String> tables;
 
-    @Override
-    public void afterPropertiesSet() {
+    @PostConstruct
+    public void init() {
         this.tables = entityManager.getMetamodel().getEntities().stream()
                                    .map(EntityType::getName)
                                    .map(this::toSnake)

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
@@ -1,7 +1,6 @@
 package com.yigongil.backend.acceptance.steps;
 
 import java.util.List;
-import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.metamodel.EntityType;
@@ -22,10 +21,10 @@ public class DatabaseCleaner implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         this.tables = entityManager.getMetamodel().getEntities().stream()
-                                   .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
                                    .map(EntityType::getName)
                                    .map(this::toSnake)
                                    .toList();
+        System.out.println("tables = " + tables);
     }
 
     private String toSnake(String camel) {

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
@@ -24,7 +24,6 @@ public class DatabaseCleaner implements InitializingBean {
                                    .map(EntityType::getName)
                                    .map(this::toSnake)
                                    .toList();
-        System.out.println("tables = " + tables);
     }
 
     private String toSnake(String camel) {


### PR DESCRIPTION
## 😋 작업한 내용

@DirtiesContext를 걷어내고 DatabaseCleaner 추가

## 🙏 PR Point

### 구현 부분

DataBaseCleaner를 test 환경에서만 빈으로 등록
~~InitializingBean의 구현체로~~ PostConstuctor를 통해 초기화 콜백 메서드에서 모든 엔티티의 이름을 snake case로 변경하고 clean에서 truncate하는 native query 실행

### 테스트 성능 비교
각각 entrypoint를 인텔리제이에서 돌렸을 때, 터미널에서 ./gradlew clean test를 돌렸을 때

### 기존 테스트 성능

![image](https://github.com/woowacourse-teams/2023-yigongil/assets/109793396/0036daeb-e82e-4d8f-91e5-cf4688ca47b5)
![image](https://github.com/woowacourse-teams/2023-yigongil/assets/109793396/0d31f894-2db5-4995-b661-867cf23d2316)

### 변경 후 테스트 성능

![image](https://github.com/woowacourse-teams/2023-yigongil/assets/109793396/a0c2249d-8c7a-4008-9001-10609fdf9ff7)
![image](https://github.com/woowacourse-teams/2023-yigongil/assets/109793396/f93300f8-9920-4772-b871-468bf8eb92ca)




## 👍 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved : #208
