### PR TITLE
[스터디 상세보기 뷰] 클릭안되는 버튼 로직 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "com.created.team201"
         minSdk 26
         targetSdk 33
-        versionCode 3
-        versionName "1.1.1"
+        versionCode 4
+        versionName "1.1.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "TEAM201_GIT_HUB_URL", properties["GIT_HUB_URL"]

--- a/android/app/src/main/java/com/created/team201/presentation/profile/ProfileActivity.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/profile/ProfileActivity.kt
@@ -78,7 +78,11 @@ class ProfileActivity : BindingActivity<ActivityProfileBinding>(R.layout.activit
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(R.menu.menu_profile, menu)
+        val isMyProfile = intent.getBooleanExtra(KEY_MY_PROFILE, false)
+        when (isMyProfile) {
+            true -> binding.tbProfile.setTitle(R.string.myPage_toolbar_title)
+            false -> menuInflater.inflate(R.menu.menu_profile, menu)
+        }
         return true
     }
 
@@ -98,9 +102,11 @@ class ProfileActivity : BindingActivity<ActivityProfileBinding>(R.layout.activit
     companion object {
         private const val NON_EXISTENCE_USER_ID = 0L
         private const val KEY_USER_ID = "KEY_USER_ID"
-        fun getIntent(context: Context, userId: Long): Intent =
+        private const val KEY_MY_PROFILE = "KEY_MY_PROFILE"
+        fun getIntent(context: Context, userId: Long, isMyProfile: Boolean = false): Intent =
             Intent(context, ProfileActivity::class.java).apply {
                 putExtra(KEY_USER_ID, userId)
+                putExtra(KEY_MY_PROFILE, isMyProfile)
             }
     }
 }

--- a/android/app/src/main/java/com/created/team201/presentation/studyDetail/StudyDetailActivity.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/studyDetail/StudyDetailActivity.kt
@@ -48,7 +48,9 @@ class StudyDetailActivity :
         binding.btnStudyDetailSub.setOnClickListener {
             if (studyDetailViewModel.state.value is Master) {
                 navigateToEditStudyView()
+                return@setOnClickListener
             }
+            showToast(R.string.study_detail_button_preparing_service)
         }
     }
 

--- a/android/app/src/main/java/com/created/team201/presentation/studyDetail/StudyDetailActivity.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/studyDetail/StudyDetailActivity.kt
@@ -149,10 +149,8 @@ class StudyDetailActivity :
     }
 
     override fun onUserClick(memberId: Long) {
-        if (studyDetailViewModel.myProfile.id == memberId) {
-            return
-        }
-        startActivity(ProfileActivity.getIntent(this, memberId))
+        val isMyProfile = studyDetailViewModel.myProfile.id == memberId
+        startActivity(ProfileActivity.getIntent(this, memberId, isMyProfile))
     }
 
     private fun observeParticipantsCount() {

--- a/android/app/src/main/java/com/created/team201/presentation/studyManagement/StudyManagementActivity.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/studyManagement/StudyManagementActivity.kt
@@ -232,12 +232,8 @@ class StudyManagementActivity :
                 toastDeletedMember()
                 return
             }
-
-            if (studyManagementViewModel.myProfile.id == id) {
-                return
-            } else {
-                startActivity(ProfileActivity.getIntent(this@StudyManagementActivity, id))
-            }
+            val isMyProfile = studyManagementViewModel.myProfile.id == id
+            startActivity(ProfileActivity.getIntent(this@StudyManagementActivity, id, isMyProfile))
         }
     }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="study_detail_study_people">스터디원</string>
     <string name="study_detail_study_capacity">참여하기(%d/%d)</string>
     <string name="study_detail_button_start_study">시작하기(%d/%d)</string>
+    <string name="study_detail_button_preparing_service">아직 준비중인 기능입니다</string>
     <string name="study_detail_dm_button_content_description">스터디장에게 문의하기</string>
     <string name="study_detail_study_accept_waiting">수락을 기다리고 있어요</string>
     <string name="study_detail_study_start_waiting">시작을 기다리고 있어요</string>


### PR DESCRIPTION
## 😋 작업한 내용

- [x] 내 프로필 클릭 시
- [x] 쪽지 버튼 클릭 시 alert 버튼
- [x] 추가적으로 동작 안하는 버튼 있나 찾아보기

## 🙏 PR Point

- 추가 로직을 더할까 했는데 그건 develop으로 들어가야할것 같아서 최소한의 기능만 넣었습니다.
(예를 들어 서버에서 찾을 수 없는 유저인 경우 아이디로 찾을 수 없는 유저 나타내기 등..)
- 혹시 제가 놓친 동작 안하는 버튼이 있다면 알려주세요.

**내 프로필 클릭 시** 
기존에는 아무 반응 없음 -> 프로필 Acitivity로 동일하게 이동, 마이페이지로 title 변경
**쪽지 버튼 클릭 시**
기존에는 아무 반응 없음 -> 준비 중이라는 toast 메시지 띄워줌



## 👍 관련 이슈

- Resolved : #451 
