### PR TITLE
[마이페이지 뷰] 리펙터링

### DIFF
--- a/android/app/src/main/java/com/created/team201/presentation/myPage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/myPage/MyPageFragment.kt
@@ -26,7 +26,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         super.onHiddenChanged(hidden)
 
         if (hidden) {
-            myPageViewModel.loadProfile()
+            myPageViewModel.resetModifyProfile()
             myPageViewModel.setProfileType(ProfileType.VIEW)
         }
     }
@@ -88,6 +88,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             when (profileType) {
                 ProfileType.VIEW -> setProfileView(false)
                 ProfileType.MODIFY -> setProfileView(true)
+                else -> Unit
             }
         }
         myPageViewModel.modifyProfileState.observe(viewLifecycleOwner) { modifyProfileState ->
@@ -111,7 +112,6 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
 
                 IDLE -> throw IllegalStateException()
             }
-            myPageViewModel.loadProfile()
         }
     }
 
@@ -139,7 +139,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     private fun onModifySaveClick(): MyPageDialogClickListener =
         object : MyPageDialogClickListener {
             override fun onCancelClick() {
-                myPageViewModel.loadProfile()
+                myPageViewModel.resetModifyProfile()
                 Toast.makeText(
                     requireContext(),
                     getString(R.string.myPage_toast_modify_profile_cancel),


### PR DESCRIPTION
## 😋 작업한 내용
- 불필요한 통신 로직 제거

## 🙏 PR Point
1. 기존에는 프래그먼트가 숨겨졌을 때, 서버에서 마이페이지 정보를 불러오고, 보기모드로 수정해줬습니다.
-> 변경: 프래그먼트가 숨겨졌을 때, **서버에서 가져오는게 아닌 뷰모델에서 관리되던 이전 원본 값으로 다시 reset 하도록 수정**
2. 기존에는 프로필 수정 다이얼로그에서 취소를 눌렀을 때, 서버에서 마이페이지 정보를 불러왔습니다.
-> 변경: 1번과 마찬가지로 **서버에서 가져오는게 아닌 뷰모델에서 관리되던 이전 원본 값으로 다시 reset 하도록 수정**

#### PS. 혹시 시간되실 때 QA까지 한 번 부탁드릴게요 제가 대충 정상동작 확인은 했는데 안 될 수도 있을 거 같아서

## 👍 관련 이슈

- Resolved : #460 
