### PR TITLE
refactor: 초안

### DIFF
--- a/backend/src/main/java/com/yigongil/backend/application/MemberService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/MemberService.java
@@ -67,17 +67,7 @@ public class MemberService {
 
     private FinishedStudyResponse createFinishedStudyResponse(StudyMember studyMember) {
         Study study = studyMember.getStudy();
-        return new FinishedStudyResponse(
-                study.getId(),
-                study.getName(),
-                study.calculateAverageTier(),
-                study.getStartAt().toLocalDate(),
-                study.getTotalRoundCount(),
-                study.getPeriodUnit().toStringFormat(study.getPeriodOfRound()),
-                study.sizeOfCurrentMembers(),
-                study.getNumberOfMaximumMembers(),
-                studyMember.isSuccess()
-        );
+        return FinishedStudyResponse.from(study, studyMember);
     }
 
     private int calculateNumberOfSuccessRounds(Member member) {

--- a/backend/src/main/java/com/yigongil/backend/application/StudyService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/StudyService.java
@@ -8,6 +8,7 @@ import com.yigongil.backend.domain.roundofmember.RoundOfMember;
 import com.yigongil.backend.domain.study.ProcessingStatus;
 import com.yigongil.backend.domain.study.Study;
 import com.yigongil.backend.domain.study.StudyRepository;
+import com.yigongil.backend.domain.study.StudyV1;
 import com.yigongil.backend.domain.studymember.Role;
 import com.yigongil.backend.domain.studymember.StudyMember;
 import com.yigongil.backend.domain.studymember.StudyMemberRepository;
@@ -58,7 +59,7 @@ public class StudyService {
 
     @Transactional
     public Long create(Member member, StudyUpdateRequest request) {
-        Study study = Study.initializeStudyOf(
+        Study study = StudyV1.initializeStudyOf(
                 request.name(),
                 request.introduction(),
                 request.numberOfMaximumMembers(),
@@ -222,23 +223,7 @@ public class StudyService {
         for (StudyMember studyMember : studyMembers) {
             Study study = studyMember.getStudy();
             response.add(
-                    new MyStudyResponse(
-                            study.getId(),
-                            study.getProcessingStatus()
-                                 .getCode(),
-                            studyMember.getRole()
-                                       .getCode(),
-                            study.getName(),
-                            study.calculateAverageTier(),
-                            study.getStartAt().toLocalDate(),
-                            study.getTotalRoundCount(),
-                            study.getPeriodUnit()
-                                 .toStringFormat(study.getPeriodOfRound()),
-                            study.getCurrentRound()
-                                 .getRoundOfMembers()
-                                 .size(),
-                            study.getNumberOfMaximumMembers()
-                    )
+                    MyStudyResponse.from(study, studyMember)
             );
         }
         return response;

--- a/backend/src/main/java/com/yigongil/backend/domain/study/StudyV1.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/StudyV1.java
@@ -1,0 +1,151 @@
+package com.yigongil.backend.domain.study;
+
+import com.yigongil.backend.domain.member.Member;
+import com.yigongil.backend.domain.round.Round;
+import com.yigongil.backend.exception.CannotStartException;
+import com.yigongil.backend.exception.InvalidProcessingStatusException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@DiscriminatorValue(value = "V1")
+@Entity
+public class StudyV1 extends Study {
+
+
+    @Column(nullable = false)
+    private Integer totalRoundCount;
+
+    @Column(nullable = false)
+    private Integer periodOfRound;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private PeriodUnit periodUnit;
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    protected StudyV1() {
+    }
+
+    @Builder
+    public StudyV1(
+            Long id,
+            String name,
+            String introduction,
+            Integer numberOfMaximumMembers,
+            ProcessingStatus processingStatus,
+            LocalDateTime endAt,
+            Integer currentRoundNumber,
+            List<Round> rounds,
+            Integer totalRoundCount,
+            Integer periodOfRound,
+            PeriodUnit periodUnit,
+            LocalDateTime startAt
+    ) {
+        super(id, name, introduction, numberOfMaximumMembers, processingStatus, endAt, currentRoundNumber, rounds);
+        this.totalRoundCount = totalRoundCount;
+        this.periodOfRound = periodOfRound;
+        this.periodUnit = periodUnit;
+        this.startAt = startAt;
+    }
+
+    public static Study initializeStudyOf(
+            String name,
+            String introduction,
+            Integer numberOfMaximumMembers,
+            LocalDateTime startAt,
+            Integer totalRoundCount,
+            String periodOfRound,
+            Member master
+    ) {
+        StudyV1 study = StudyV1.builder()
+                               .name(name)
+                               .numberOfMaximumMembers(numberOfMaximumMembers)
+                               .startAt(startAt)
+                               .totalRoundCount(totalRoundCount)
+                               .periodOfRound(PeriodUnit.getPeriodNumber(periodOfRound))
+                               .periodUnit(PeriodUnit.getPeriodUnit(periodOfRound))
+                               .introduction(introduction)
+                               .processingStatus(ProcessingStatus.RECRUITING)
+                               .build();
+        study.rounds = Round.of(totalRoundCount, master);
+        return study;
+    }
+
+    @Override
+    public boolean isCurrentRoundEndAt(LocalDate today) {
+        return getCurrentRound().isEndAt(today);
+    }
+
+    @Override
+    public void startStudy() {
+        if (processingStatus != ProcessingStatus.RECRUITING) {
+            throw new CannotStartException("시작할 수 없는 상태입니다.", id);
+        }
+        if (sizeOfCurrentMembers() == ONE_MEMBER) {
+            throw new CannotStartException("시작할 수 없는 상태입니다.", id);
+        }
+        this.startAt = LocalDateTime.now();
+        this.processingStatus = ProcessingStatus.PROCESSING;
+        initializeRoundsEndAt();
+    }
+
+    private void initializeRoundsEndAt() {
+        rounds.sort(Comparator.comparing(Round::getRoundNumber));
+        LocalDateTime date = LocalDateTime.of(startAt.toLocalDate(), LocalTime.MIN);
+        for (Round round : rounds) {
+            date = date.plusDays(calculateStudyPeriod());
+            round.updateEndAt(date);
+        }
+    }
+
+    @Override
+    public int calculateStudyPeriod() {
+        return periodOfRound * periodUnit.getUnitNumber();
+    }
+
+    @Override
+    public String findPeriodOfRoundToString() {
+        return periodUnit.toStringFormat(periodOfRound);
+    }
+
+    @Override
+    public void updateInformation(
+            Member member,
+            String name,
+            Integer numberOfMaximumMembers,
+            LocalDateTime startAt,
+            Integer totalRoundCount,
+            String periodOfRound,
+            String introduction
+    ) {
+        validateMaster(member);
+        validateStudyProcessingStatus();
+        this.name = name;
+        this.numberOfMaximumMembers = numberOfMaximumMembers;
+        this.startAt = startAt;
+        this.totalRoundCount = totalRoundCount;
+        this.periodOfRound = PeriodUnit.getPeriodNumber(periodOfRound);
+        this.periodUnit = PeriodUnit.getPeriodUnit(periodOfRound);
+        this.introduction = introduction;
+    }
+
+    private void validateStudyProcessingStatus() {
+        if (isNotRecruiting()) {
+            throw new InvalidProcessingStatusException("현재 스터디의 상태가 모집중이 아닙니다.",
+                    processingStatus.name());
+        }
+    }
+}

--- a/backend/src/main/java/com/yigongil/backend/domain/study/StudyV1.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/StudyV1.java
@@ -19,7 +19,7 @@ import lombok.Getter;
 
 @Getter
 @DiscriminatorValue(value = "V1")
-@Entity
+@Entity(name = "study_v1")
 public class StudyV1 extends Study {
 
 

--- a/backend/src/main/java/com/yigongil/backend/domain/study/StudyV2.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/StudyV2.java
@@ -1,0 +1,58 @@
+package com.yigongil.backend.domain.study;
+
+import com.yigongil.backend.domain.member.Member;
+import com.yigongil.backend.domain.round.Round;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import lombok.Getter;
+
+@Getter
+@DiscriminatorValue(value = "V2")
+@Entity
+public class StudyV2 extends Study {
+
+    private Integer roundsPerWeek;
+    private Integer minimumWeek;
+
+    protected StudyV2() {
+    }
+
+    @Override
+    public void startStudy() {
+
+    }
+
+    @Override
+    public int calculateStudyPeriod() {
+        return 0;
+    }
+
+    @Override
+    public String findPeriodOfRoundToString() {
+        return null;
+    }
+
+    @Override
+    public void updateInformation(Member member, String name, Integer numberOfMaximumMembers, LocalDateTime startAt, Integer totalRoundCount, String periodOfRound, String introduction) {
+
+    }
+
+    public StudyV2(
+            Long id,
+            String name,
+            String introduction,
+            Integer numberOfMaximumMembers,
+            ProcessingStatus processingStatus,
+            LocalDateTime endAt,
+            Integer currentRoundNumber,
+            List<Round> rounds,
+            Integer roundsPerWeek,
+            Integer minimumWeek
+    ) {
+        super(id, name, introduction, numberOfMaximumMembers, processingStatus, endAt, currentRoundNumber, rounds);
+        this.roundsPerWeek = roundsPerWeek;
+        this.minimumWeek = minimumWeek;
+    }
+}

--- a/backend/src/main/java/com/yigongil/backend/domain/study/StudyV2.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/StudyV2.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 @Getter
 @DiscriminatorValue(value = "V2")
-@Entity
+@Entity(name = "study_v2")
 public class StudyV2 extends Study {
 
     private Integer roundsPerWeek;

--- a/backend/src/main/java/com/yigongil/backend/response/FinishedStudyResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/FinishedStudyResponse.java
@@ -1,5 +1,8 @@
 package com.yigongil.backend.response;
 
+import com.yigongil.backend.domain.study.Study;
+import com.yigongil.backend.domain.study.StudyV1;
+import com.yigongil.backend.domain.studymember.StudyMember;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
@@ -23,5 +26,20 @@ public record FinishedStudyResponse(
         @Schema(example = "true")
         Boolean isSucceed
 ) {
+
+    public static FinishedStudyResponse from(Study study, StudyMember studyMember) {
+        StudyV1 studyV1 = (StudyV1) study;
+        return new FinishedStudyResponse(
+                studyV1.getId(),
+                studyV1.getName(),
+                studyV1.calculateAverageTier(),
+                studyV1.getStartAt().toLocalDate(),
+                studyV1.getTotalRoundCount(),
+                studyV1.getPeriodUnit().toStringFormat(studyV1.getPeriodOfRound()),
+                studyV1.sizeOfCurrentMembers(),
+                studyV1.getNumberOfMaximumMembers(),
+                studyMember.isSuccess()
+        );
+    }
 
 }

--- a/backend/src/main/java/com/yigongil/backend/response/MyStudyResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/MyStudyResponse.java
@@ -1,5 +1,8 @@
 package com.yigongil.backend.response;
 
+import com.yigongil.backend.domain.study.Study;
+import com.yigongil.backend.domain.study.StudyV1;
+import com.yigongil.backend.domain.studymember.StudyMember;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
@@ -25,5 +28,26 @@ public record MyStudyResponse(
         @Schema(example = "5")
         Integer numberOfMaximumMembers
 ) {
+
+    public static MyStudyResponse from(Study study, StudyMember studyMember) {
+        StudyV1 studyV1 = (StudyV1) study;
+        return new MyStudyResponse(
+                studyV1.getId(),
+                studyV1.getProcessingStatus()
+                       .getCode(),
+                studyMember.getRole()
+                           .getCode(),
+                studyV1.getName(),
+                studyV1.calculateAverageTier(),
+                studyV1.getStartAt().toLocalDate(),
+                studyV1.getTotalRoundCount(),
+                studyV1.getPeriodUnit()
+                       .toStringFormat(studyV1.getPeriodOfRound()),
+                studyV1.getCurrentRound()
+                       .getRoundOfMembers()
+                       .size(),
+                studyV1.getNumberOfMaximumMembers()
+        );
+    }
 
 }

--- a/backend/src/main/java/com/yigongil/backend/response/RecruitingStudyResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/RecruitingStudyResponse.java
@@ -1,6 +1,7 @@
 package com.yigongil.backend.response;
 
 import com.yigongil.backend.domain.study.Study;
+import com.yigongil.backend.domain.study.StudyV1;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
@@ -26,16 +27,17 @@ public record RecruitingStudyResponse(
 ) {
 
     public static RecruitingStudyResponse from(Study study) {
+        StudyV1 studyV1 = (StudyV1) study;
         return new RecruitingStudyResponse(
-                study.getId(),
-                study.getProcessingStatus().getCode(),
-                study.getName(),
-                study.calculateAverageTier(),
-                study.getStartAt().toLocalDate(),
-                study.getTotalRoundCount(),
-                study.getPeriodUnit().toStringFormat(study.getPeriodOfRound()),
-                study.sizeOfCurrentMembers(),
-                study.getNumberOfMaximumMembers()
+                studyV1.getId(),
+                studyV1.getProcessingStatus().getCode(),
+                studyV1.getName(),
+                studyV1.calculateAverageTier(),
+                studyV1.getStartAt().toLocalDate(),
+                studyV1.getTotalRoundCount(),
+                studyV1.getPeriodUnit().toStringFormat(studyV1.getPeriodOfRound()),
+                studyV1.sizeOfCurrentMembers(),
+                studyV1.getNumberOfMaximumMembers()
         );
     }
 }

--- a/backend/src/main/java/com/yigongil/backend/response/StudyDetailResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/StudyDetailResponse.java
@@ -2,8 +2,8 @@ package com.yigongil.backend.response;
 
 import com.yigongil.backend.domain.round.Round;
 import com.yigongil.backend.domain.study.Study;
+import com.yigongil.backend.domain.study.StudyV1;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -40,18 +40,19 @@ public record StudyDetailResponse(
             Round currentRound,
             List<StudyMemberResponse> studyMemberResponses
     ) {
+        StudyV1 studyV1 = (StudyV1) study;
         return new StudyDetailResponse(
-                study.getId(),
-                study.getProcessingStatus().getCode(),
-                study.getName(),
+                studyV1.getId(),
+                studyV1.getProcessingStatus().getCode(),
+                studyV1.getName(),
                 currentRound.getRoundOfMembers().size(),
-                study.getNumberOfMaximumMembers(),
+                studyV1.getNumberOfMaximumMembers(),
                 currentRound.getMaster().getId(),
-                study.getStartAt().toLocalDate(),
-                study.getTotalRoundCount(),
-                study.findPeriodOfRoundToString(),
-                study.getCurrentRound().getRoundNumber(),
-                study.getIntroduction(),
+                studyV1.getStartAt().toLocalDate(),
+                studyV1.getTotalRoundCount(),
+                studyV1.findPeriodOfRoundToString(),
+                studyV1.getCurrentRound().getRoundNumber(),
+                studyV1.getIntroduction(),
                 studyMemberResponses,
                 RoundNumberResponse.from(rounds)
         );

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
@@ -33,29 +33,11 @@ public class DatabaseCleaner {
                 if (strategy == InheritanceType.SINGLE_TABLE) {
                     continue;
                 }
-                tables.add(toSnake(entity.getSimpleName().toLowerCase()));
+                tables.add(toSnake(entity.getSimpleName()));
                 continue;
             }
             tables.add(toSnake(entity.getSimpleName()));
         }
-
-        System.out.println("tables = " + tables);
-//        List<String> l = clazz.stream()
-//                              .filter(aClass -> !aClass.getSuperclass().isAnnotationPresent(Inheritance.class))
-//                              .map(Class::getSimpleName)
-//                              .map(this::toSnake)
-//                              .toList();
-//        tables.addAll(l);
-//        tables.add("studyv1");
-//        tables.add("studyv2");
-
-//        this.tables = entityManager.getMetamodel().getEntities().stream()
-//                                   .filter(entityType -> entityType.getJavaType().getSuperclass()
-//                                                                   .getSimpleName()
-//                                                                   .equals("BaseEntity"))
-//                                   .map(EntityType::getName)
-//                                   .map(this::toSnake)
-//                                   .toList();
     }
 
     private String toSnake(String camel) {

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
@@ -33,11 +33,12 @@ public class DatabaseCleaner {
                 if (strategy == InheritanceType.SINGLE_TABLE) {
                     continue;
                 }
-                tables.add(toSnake(entity.getSimpleName()));
+                tables.add(toSnake(entity.getSimpleName().toLowerCase()));
                 continue;
             }
             tables.add(toSnake(entity.getSimpleName()));
         }
+        System.out.println("tables = " + tables);
     }
 
     private String toSnake(String camel) {

--- a/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
+++ b/backend/src/test/java/com/yigongil/backend/acceptance/steps/DatabaseCleaner.java
@@ -33,12 +33,11 @@ public class DatabaseCleaner {
                 if (strategy == InheritanceType.SINGLE_TABLE) {
                     continue;
                 }
-                tables.add(toSnake(entity.getSimpleName().toLowerCase()));
+                tables.add(toSnake(entity.getSimpleName()));
                 continue;
             }
             tables.add(toSnake(entity.getSimpleName()));
         }
-        System.out.println("tables = " + tables);
     }
 
     private String toSnake(String camel) {

--- a/backend/src/test/java/com/yigongil/backend/domain/study/StudyRepositoryTest.java
+++ b/backend/src/test/java/com/yigongil/backend/domain/study/StudyRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.yigongil.backend.domain.study;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yigongil.backend.config.JpaConfig;
+import com.yigongil.backend.fixture.StudyFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Import(JpaConfig.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@DataJpaTest
+class StudyRepositoryTest {
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Test
+    void 레퍼지토리_타입_테스트() {
+        Study save = studyRepository.save(StudyFixture.자바_스터디_모집중.toStudy());
+
+        Study study = studyRepository.findById(save.getId()).get();
+
+        assertThat(study).isInstanceOf(StudyV1.class);
+    }
+
+    @Test
+    void 레퍼지토리_타입_테스트2() {
+        Study save = studyRepository.save(StudyFixture.자바_스터디_모집중.toStudy());
+
+        Study study = studyRepository.findById(save.getId()).get();
+
+        assertThat(study).isNotInstanceOf(StudyV2.class);
+    }
+}

--- a/backend/src/test/java/com/yigongil/backend/fixture/StudyFixture.java
+++ b/backend/src/test/java/com/yigongil/backend/fixture/StudyFixture.java
@@ -8,6 +8,7 @@ import com.yigongil.backend.domain.round.Round;
 import com.yigongil.backend.domain.study.PeriodUnit;
 import com.yigongil.backend.domain.study.ProcessingStatus;
 import com.yigongil.backend.domain.study.Study;
+import com.yigongil.backend.domain.study.StudyV1;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,18 +45,19 @@ public enum StudyFixture {
     }
 
     public Study toStudy() {
-        return Study.builder()
-                    .id(id)
-                    .startAt(startAt)
-                    .name(name)
-                    .introduction(introduction)
-                    .periodOfRound(periodOfRound)
-                    .processingStatus(processingStatus)
-                    .totalRoundCount(totalRoundCount)
-                    .periodUnit(periodUnit)
-                    .numberOfMaximumMembers(numberOfMaximumMember)
-                    .rounds(List.of(아이디없는_라운드.toRound(), 아이디없는_라운드2.toRound(), 아이디없는_라운드3.toRound()))
-                    .build();
+
+        return StudyV1.builder()
+                      .id(id)
+                      .startAt(startAt)
+                      .name(name)
+                      .introduction(introduction)
+                      .periodOfRound(periodOfRound)
+                      .processingStatus(processingStatus)
+                      .totalRoundCount(totalRoundCount)
+                      .periodUnit(periodUnit)
+                      .numberOfMaximumMembers(numberOfMaximumMember)
+                      .rounds(List.of(아이디없는_라운드.toRound(), 아이디없는_라운드2.toRound(), 아이디없는_라운드3.toRound()))
+                      .build();
     }
 
     public Study toStudyWithRounds(RoundFixture... roundFixtures) {
@@ -63,17 +65,17 @@ public enum StudyFixture {
                                                    .map(RoundFixture::toRound)
                                                    .toList());
 
-        return Study.builder()
-                    .id(id)
-                    .startAt(startAt)
-                    .name(name)
-                    .introduction(introduction)
-                    .periodOfRound(periodOfRound)
-                    .processingStatus(processingStatus)
-                    .totalRoundCount(totalRoundCount)
-                    .periodUnit(periodUnit)
-                    .numberOfMaximumMembers(numberOfMaximumMember)
-                    .rounds(rounds)
-                    .build();
+        return StudyV1.builder()
+                      .id(id)
+                      .startAt(startAt)
+                      .name(name)
+                      .introduction(introduction)
+                      .periodOfRound(periodOfRound)
+                      .processingStatus(processingStatus)
+                      .totalRoundCount(totalRoundCount)
+                      .periodUnit(periodUnit)
+                      .numberOfMaximumMembers(numberOfMaximumMember)
+                      .rounds(rounds)
+                      .build();
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -18,7 +18,7 @@ spring:
         format_sql: true
         show_sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
   flyway:
     enabled: false


### PR DESCRIPTION
## 😋 작업한 내용

일단 초안인데요

저희 이거 할 수 있는거 맞나요?
필드를 인터페이스로 나누는건 불가능하고 결국 상속으로 V1 V2를 만드는게 최선같은데 확장성이 있는지 의문이..
일단 V1 V2 구분하고 테스트/컴파일 가능하게 해놨는데 결국 response도 두개를 만들거나 둘다 포함한 response로 바꿔야 할 것 같고 결국엔 service도 분리해야될 것 같은데 쉽지 않네여 

## 🙏 PR Point

- 

## 👍 관련 이슈

- Resolved : #


---

## 기획의 어떤 부분을 구현 / 수정했는가 (굉장히 상세하게 적어주세요, 해당 커밋의 링크, 코드의 위치를 남겨주면 더욱 좋습니다.)

밑은 예시입니다.

**[시작되면서 스터디의 주 몇 회 정보를 유저가 실제로 선택한 일 수로 수정](http://관련기획링크)**
  - StudyService의 createStudy 메서드에서 PeriodOfRound 를 받지 않도록 수정했습니다. [해당커밋](http://커밋링크)
  - Study의 start 메서드에서 파라미터로 시작한 날짜를 받도록 구현하였습니다.
  - 날짜(월화수목금토일)를 뜻하는 Enum을 Study 패키지에 추가하였습니다.
  - flyway에서 해당 엔티티에 필요할 칼럼을 수정했습니다.

**[스터디가 더 이상 종료되지 않도록 수정](http://관련기획링크)**
  - 상동 
