### PR TITLE
feat: s3 이미지 업로드 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     // aws
     implementation platform('software.amazon.awssdk:bom:2.20.56')
     implementation 'software.amazon.awssdk:cloudwatch'
+    implementation 'software.amazon.awssdk:s3'
 
     // queryDsl-jpa
     implementation 'com.querydsl:querydsl-jpa:5.0.0'
@@ -80,5 +81,3 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-

--- a/backend/src/main/java/com/yigongil/backend/application/ImageResourceService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/ImageResourceService.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -13,6 +14,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Profile(value = {"prod", "dev"})
 @Service
 public class ImageResourceService {
 

--- a/backend/src/main/java/com/yigongil/backend/application/ImageResourceService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/ImageResourceService.java
@@ -1,0 +1,79 @@
+package com.yigongil.backend.application;
+
+import com.yigongil.backend.exception.ImageToBytesException;
+import com.yigongil.backend.exception.InvalidImageExtensionException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+public class ImageResourceService {
+
+    private final String BUCKET_NAME;
+    private final String CLOUD_FRONT_DOMAIN_NAME;
+    private final S3Client S3_CLIENT;
+
+    public ImageResourceService(
+            @Value("${aws.region}") String region,
+            @Value("${aws.s3.bucket-name}") String bucketName,
+            @Value("${aws.cloud-front-domain}") String cloudFrontDomainName
+    ) {
+        BUCKET_NAME = bucketName;
+        CLOUD_FRONT_DOMAIN_NAME = cloudFrontDomainName;
+        S3_CLIENT = S3Client.builder()
+                            .region(Region.of(region))
+                            .build();
+    }
+
+    public String uploadImage(MultipartFile image) {
+        String key = createKey(ImageExtension.from(image.getOriginalFilename()));
+        try {
+            S3_CLIENT.putObject(
+                    PutObjectRequest.builder()
+                                    .bucket(BUCKET_NAME)
+                                    .key(key)
+                                    .build(),
+                    RequestBody.fromBytes(image.getBytes())
+            );
+            return CLOUD_FRONT_DOMAIN_NAME + "/" + key;
+        } catch (IOException e) {
+            throw new ImageToBytesException(e);
+        }
+    }
+
+    private String createKey(ImageExtension extension) {
+        return UUID.randomUUID() + extension.toString();
+    }
+
+    enum ImageExtension {
+
+        JPG(".jpg"),
+        JPEG(".jpeg"),
+        PNG(".png");
+
+        private final String extension;
+
+        ImageExtension(String extension) {
+            this.extension = extension;
+        }
+
+        public static ImageExtension from(String fileName) {
+            return Arrays.stream(values())
+                         .filter(value -> fileName.endsWith(value.extension))
+                         .findAny()
+                         .orElseThrow(() -> new InvalidImageExtensionException("Invalid image extension", fileName));
+        }
+
+        @Override
+        public String toString() {
+            return extension;
+        }
+    }
+}

--- a/backend/src/main/java/com/yigongil/backend/exception/ImageToBytesException.java
+++ b/backend/src/main/java/com/yigongil/backend/exception/ImageToBytesException.java
@@ -1,0 +1,11 @@
+package com.yigongil.backend.exception;
+
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+
+public class ImageToBytesException extends HttpException {
+
+    public ImageToBytesException(IOException e) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), "Failed to convert image to bytes");
+    }
+}

--- a/backend/src/main/java/com/yigongil/backend/exception/InvalidImageExtensionException.java
+++ b/backend/src/main/java/com/yigongil/backend/exception/InvalidImageExtensionException.java
@@ -1,0 +1,10 @@
+package com.yigongil.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidImageExtensionException extends HttpException {
+
+    public InvalidImageExtensionException(String message, String input) {
+        super(HttpStatus.BAD_REQUEST, message, input);
+    }
+}

--- a/backend/src/main/java/com/yigongil/backend/ui/ImageResourceController.java
+++ b/backend/src/main/java/com/yigongil/backend/ui/ImageResourceController.java
@@ -1,0 +1,25 @@
+package com.yigongil.backend.ui;
+
+import com.yigongil.backend.application.ImageResourceService;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController("/v1/images")
+public class ImageResourceController {
+
+    private final ImageResourceService imageResourceService;
+
+    public ImageResourceController(ImageResourceService imageResourceService) {
+        this.imageResourceService = imageResourceService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> uploadImage(@RequestPart MultipartFile image) {
+        return ResponseEntity.created(URI.create(imageResourceService.uploadImage(image)))
+                             .build();
+    }
+}

--- a/backend/src/main/java/com/yigongil/backend/ui/ImageResourceController.java
+++ b/backend/src/main/java/com/yigongil/backend/ui/ImageResourceController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @Profile(value = {"prod", "dev"})
-@RestController("/v1/images")
+@RestController("/images")
 public class ImageResourceController {
 
     private final ImageResourceService imageResourceService;

--- a/backend/src/main/java/com/yigongil/backend/ui/ImageResourceController.java
+++ b/backend/src/main/java/com/yigongil/backend/ui/ImageResourceController.java
@@ -2,12 +2,14 @@ package com.yigongil.backend.ui;
 
 import com.yigongil.backend.application.ImageResourceService;
 import java.net.URI;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Profile(value = {"prod", "dev"})
 @RestController("/v1/images")
 public class ImageResourceController {
 


### PR DESCRIPTION
## 😋 작업한 내용

- 클라이언트로부터 받은 이미지를 s3에 업로드하는 기능을 추가한다.

## 🙏 PR Point

- 업로드 중 에러 발생 시, s3 오브젝트에 대한 처리를 어떻게 할 수 있을지
- url을 이런식으로 분리해도 괜찮을지
- 내부 enum 사용

## 👍 관련 이슈

- Resolved : #463 

---

## 기획의 어떤 부분을 구현 / 수정했는가

**[다음 스프린트 예정인 s3업로드 기능 미리 구현](https://www.notion.so/6-948a8ac862f04bbe96af6aa547ad1db6?pvs=4)**
  - 먼저 멀티파트 파일을 "v1/images" 경로로 받은 후, Service 객체에 넘기고 이를 업로드 한 후, 저장된 위치를 Location 헤더로 응답합니다.
  - 멀티파트 파일의 키(s3 에 저장되는 파일 이름)는 고유해야하므로 UUID + 확장자로 지정하였습니다.
  - async로 구현할까 잠깐 고민했는데, 어차피 엔드포인트를 나누게 되면 클라이언트만 async하게 처리해주면 될 것 같아 동기식으로 구현하였습니다.

