### PR TITLE
엔티티를 수정하며 발생한 컴파일 에러 해결

### DIFF
--- a/backend/src/main/java/com/yigongil/backend/application/MemberService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/MemberService.java
@@ -72,8 +72,6 @@ public class MemberService {
                 study.getName(),
                 study.calculateAverageTier(),
                 study.getStartAt().toLocalDate(),
-                study.getTotalRoundCount(),
-                study.getPeriodUnit().toStringFormat(study.getPeriodOfRound()),
                 study.sizeOfCurrentMembers(),
                 study.getNumberOfMaximumMembers(),
                 studyMember.isSuccess()

--- a/backend/src/main/java/com/yigongil/backend/application/StudyService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/StudyService.java
@@ -63,8 +63,6 @@ public class StudyService {
                 request.introduction(),
                 request.numberOfMaximumMembers(),
                 request.startAt().atStartOfDay(),
-                request.totalRoundCount(),
-                request.periodOfRound(),
                 member
         );
 
@@ -231,9 +229,6 @@ public class StudyService {
                             study.getName(),
                             study.calculateAverageTier(),
                             study.getStartAt().toLocalDate(),
-                            study.getTotalRoundCount(),
-                            study.getPeriodUnit()
-                                 .toStringFormat(study.getPeriodOfRound()),
                             study.getCurrentRound()
                                  .getRoundOfMembers()
                                  .size(),
@@ -292,8 +287,6 @@ public class StudyService {
                 request.name(),
                 request.numberOfMaximumMembers(),
                 request.startAt().atStartOfDay(),
-                request.totalRoundCount(),
-                request.periodOfRound(),
                 request.introduction()
         );
     }

--- a/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
@@ -8,26 +8,19 @@ import com.yigongil.backend.exception.InvalidMemberSizeException;
 import com.yigongil.backend.exception.InvalidNumberOfMaximumStudyMember;
 import com.yigongil.backend.exception.InvalidProcessingStatusException;
 import com.yigongil.backend.exception.InvalidStudyNameLengthException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Entity
@@ -38,6 +31,7 @@ public class Study extends BaseEntity {
     private static final int MAX_NAME_LENGTH = 30;
     private static final int MIN_MEMBER_SIZE = 2;
     private static final int MAX_MEMBER_SIZE = 8;
+    private static final int INITIAL_ROUND_COUNT = 2;
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -109,21 +103,16 @@ public class Study extends BaseEntity {
         String introduction,
         Integer numberOfMaximumMembers,
         LocalDateTime startAt,
-        Integer totalRoundCount,
-        String periodOfRound,
         Member master
     ) {
         Study study = Study.builder()
                              .name(name)
                              .numberOfMaximumMembers(numberOfMaximumMembers)
                              .startAt(startAt)
-                             .totalRoundCount(totalRoundCount)
-                             .periodOfRound(PeriodUnit.getPeriodNumber(periodOfRound))
-                             .periodUnit(PeriodUnit.getPeriodUnit(periodOfRound))
                              .introduction(introduction)
                              .processingStatus(ProcessingStatus.RECRUITING)
                              .build();
-        study.rounds = Round.of(totalRoundCount, master);
+        study.rounds = Round.of(INITIAL_ROUND_COUNT, master);
         return study;
     }
 
@@ -244,7 +233,7 @@ public class Study extends BaseEntity {
         return getCurrentRound().isMaster(member);
     }
 
-    protected void updateInformation(Member member, String name, Integer numberOfMaximumMembers, LocalDateTime startAt, String introduction) {
+    public void updateInformation(Member member, String name, Integer numberOfMaximumMembers, LocalDateTime startAt, String introduction) {
         validateName(name);
         validateNumberOfMaximumMembers(numberOfMaximumMembers);
         validateMaster(member);
@@ -254,4 +243,5 @@ public class Study extends BaseEntity {
         this.startAt = startAt;
         this.introduction = introduction;
     }
+
 }

--- a/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
@@ -4,10 +4,7 @@ import com.yigongil.backend.domain.BaseEntity;
 import com.yigongil.backend.domain.member.Member;
 import com.yigongil.backend.domain.round.Round;
 import com.yigongil.backend.domain.roundofmember.RoundOfMember;
-import com.yigongil.backend.exception.InvalidMemberSizeException;
-import com.yigongil.backend.exception.InvalidNumberOfMaximumStudyMember;
-import com.yigongil.backend.exception.InvalidProcessingStatusException;
-import com.yigongil.backend.exception.InvalidStudyNameLengthException;
+import com.yigongil.backend.exception.*;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.Cascade;
@@ -18,7 +15,9 @@ import org.hibernate.annotations.OnDeleteAction;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -244,4 +243,23 @@ public class Study extends BaseEntity {
         this.introduction = introduction;
     }
 
+    public void startStudy() {
+        if (processingStatus != ProcessingStatus.RECRUITING) {
+            throw new CannotStartException("시작할 수 없는 상태입니다.", id);
+        }
+        if (sizeOfCurrentMembers() == ONE_MEMBER) {
+            throw new CannotStartException("시작할 수 없는 상태입니다.", id);
+        }
+        this.startAt = LocalDateTime.now();
+        this.processingStatus = ProcessingStatus.PROCESSING;
+        initializeRoundsEndAt();
+    }
+
+    private void initializeRoundsEndAt() {
+        rounds.sort(Comparator.comparing(Round::getRoundNumber));
+        LocalDateTime date = LocalDateTime.of(startAt.toLocalDate(), LocalTime.MIN);
+        for (Round round : rounds) {
+            // TODO: 10/5/23 진행하고자 하는 요일들로 초기화 필요
+        }
+    }
 }

--- a/backend/src/main/java/com/yigongil/backend/domain/studymember/StudyMember.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/studymember/StudyMember.java
@@ -75,7 +75,8 @@ public class StudyMember extends BaseEntity {
     public void completeSuccessfully() {
         int successfulRoundCount = study.calculateSuccessfulRoundCount(member);
         int defaultRoundExperience = EXPERIENCE_BASE_UNIT * 2;
-        int additionalExperienceOfPeriodLength = EXPERIENCE_BASE_UNIT * study.calculateStudyPeriod();
+        int additionalExperienceOfPeriodLength = EXPERIENCE_BASE_UNIT * 1;
+        // TODO: 10/5/23 기존의 스터디 주기(일 수)만큼 곱했었던 로직 변경이 필요함. 일단 1을 곱하는 것으로 수정
         int totalExperience = successfulRoundCount * (defaultRoundExperience + additionalExperienceOfPeriodLength);
         member.addExperience(totalExperience);
         this.studyResult = StudyResult.SUCCESS;

--- a/backend/src/main/java/com/yigongil/backend/response/FinishedStudyResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/FinishedStudyResponse.java
@@ -12,10 +12,6 @@ public record FinishedStudyResponse(
         Integer averageTier,
         @Schema(example = "2023.08.12")
         LocalDate startAt,
-        @Schema(example = "5")
-        Integer totalRoundCount,
-        @Schema(example = "1w")
-        String periodOfRound,
         @Schema(example = "3")
         Integer numberOfCurrentMembers,
         @Schema(example = "4")

--- a/backend/src/main/java/com/yigongil/backend/response/MyStudyResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/MyStudyResponse.java
@@ -16,10 +16,6 @@ public record MyStudyResponse(
         Integer averageTier,
         @Schema(example = "2023.08.30")
         LocalDate startAt,
-        @Schema(example = "5")
-        Integer totalRoundCount,
-        @Schema(example = "1d")
-        String periodOfRound,
         @Schema(example = "3")
         Integer numberOfCurrentMembers,
         @Schema(example = "5")

--- a/backend/src/main/java/com/yigongil/backend/response/RecruitingStudyResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/RecruitingStudyResponse.java
@@ -15,10 +15,6 @@ public record RecruitingStudyResponse(
         Integer averageTier,
         @Schema(example = "2023.08.13")
         LocalDate startAt,
-        @Schema(example = "10")
-        Integer totalRoundCount,
-        @Schema(example = "3d")
-        String periodOfRound,
         @Schema(example = "6")
         Integer numberOfCurrentMembers,
         @Schema(example = "6")
@@ -32,8 +28,6 @@ public record RecruitingStudyResponse(
                 study.getName(),
                 study.calculateAverageTier(),
                 study.getStartAt().toLocalDate(),
-                study.getTotalRoundCount(),
-                study.getPeriodUnit().toStringFormat(study.getPeriodOfRound()),
                 study.sizeOfCurrentMembers(),
                 study.getNumberOfMaximumMembers()
         );

--- a/backend/src/main/java/com/yigongil/backend/response/StudyDetailResponse.java
+++ b/backend/src/main/java/com/yigongil/backend/response/StudyDetailResponse.java
@@ -22,10 +22,6 @@ public record StudyDetailResponse(
         Long studyMasterId,
         @Schema(example = "2023.08.12")
         LocalDate startAt,
-        @Schema(example = "5")
-        Integer totalRoundCount,
-        @Schema(example = "1w")
-        String periodOfRound,
         @Schema(example = "1")
         Integer currentRound,
         @Schema(example = "코틀린으로 다 뿌수는 스터디입니다")
@@ -48,8 +44,6 @@ public record StudyDetailResponse(
                 study.getNumberOfMaximumMembers(),
                 currentRound.getMaster().getId(),
                 study.getStartAt().toLocalDate(),
-                study.getTotalRoundCount(),
-                study.findPeriodOfRoundToString(),
                 study.getCurrentRound().getRoundNumber(),
                 study.getIntroduction(),
                 studyMemberResponses,

--- a/backend/src/test/java/com/yigongil/backend/domain/study/StudyTest.java
+++ b/backend/src/test/java/com/yigongil/backend/domain/study/StudyTest.java
@@ -148,12 +148,13 @@ class StudyTest {
         study.startStudy();
         List<Round> rounds = study.getRounds();
 
-        assertThat(rounds).map(Round::getEndAt)
-                          .containsExactlyInAnyOrder(
-                                  LocalDate.now().atStartOfDay().plus(study.calculateStudyPeriod(), ChronoUnit.DAYS),
-                                  LocalDate.now().atStartOfDay().plus(study.calculateStudyPeriod() * 2L, ChronoUnit.DAYS),
-                                  LocalDate.now().atStartOfDay().plus(study.calculateStudyPeriod() * 3L, ChronoUnit.DAYS)
-                          );
+//        assertThat(rounds).map(Round::getEndAt)
+//                          .containsExactlyInAnyOrder(
+//                                  LocalDate.now().atStartOfDay().plus(study.calculateStudyPeriod(), ChronoUnit.DAYS),
+//                                  LocalDate.now().atStartOfDay().plus(study.calculateStudyPeriod() * 2L, ChronoUnit.DAYS),
+//                                  LocalDate.now().atStartOfDay().plus(study.calculateStudyPeriod() * 3L, ChronoUnit.DAYS)
+//                          );
+        // TODO: 10/5/23 기존에는 스터디 주기만큼 더해졌으나, 요일로 바뀌면서 테스트 방식도 변경이 필요함
 
     }
 }

--- a/backend/src/test/java/com/yigongil/backend/domain/study/StudyTest.java
+++ b/backend/src/test/java/com/yigongil/backend/domain/study/StudyTest.java
@@ -1,9 +1,5 @@
 package com.yigongil.backend.domain.study;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.yigongil.backend.domain.member.Member;
 import com.yigongil.backend.domain.round.Round;
 import com.yigongil.backend.exception.InvalidMemberSizeException;
@@ -11,12 +7,15 @@ import com.yigongil.backend.exception.InvalidProcessingStatusException;
 import com.yigongil.backend.fixture.MemberFixture;
 import com.yigongil.backend.fixture.RoundFixture;
 import com.yigongil.backend.fixture.StudyFixture;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class StudyTest {
 
@@ -130,8 +129,6 @@ class StudyTest {
                 "이름 수정",
                 5,
                 LocalDateTime.now(),
-                5,
-                "3d",
                 "소개"
         );
 

--- a/backend/src/test/java/com/yigongil/backend/fixture/StudyFixture.java
+++ b/backend/src/test/java/com/yigongil/backend/fixture/StudyFixture.java
@@ -14,29 +14,25 @@ import java.util.List;
 
 public enum StudyFixture {
 
-    자바_스터디_진행중(1L, LocalDateTime.now(), "자바", "스터디소개", 3, ProcessingStatus.PROCESSING, 3, 4),
-    자바_스터디_모집중(1L, LocalDateTime.now(), "자바", "스터디소개", 3, ProcessingStatus.RECRUITING, 3, 4),
-    자바_스터디_모집중_정원_2(1L, LocalDateTime.now(), "자바", "스터디소개", 3, ProcessingStatus.RECRUITING, 3, 2),
+    자바_스터디_진행중(1L, LocalDateTime.now(), "자바", "스터디소개", ProcessingStatus.PROCESSING, 4),
+    자바_스터디_모집중(1L, LocalDateTime.now(), "자바", "스터디소개", ProcessingStatus.RECRUITING, 4),
+    자바_스터디_모집중_정원_2(1L, LocalDateTime.now(), "자바", "스터디소개", ProcessingStatus.RECRUITING, 2),
     ;
 
     private final Long id;
     private final LocalDateTime startAt;
     private final String name;
     private final String introduction;
-    private final Integer periodOfRound;
     private final ProcessingStatus processingStatus;
-    private final Integer totalRoundCount;
     private final Integer numberOfMaximumMember;
 
-    StudyFixture(Long id, LocalDateTime startAt, String name, String introduction, Integer periodOfRound,
-            ProcessingStatus processingStatus, Integer totalRoundCount, Integer numberOfMaximumMember) {
+    StudyFixture(Long id, LocalDateTime startAt, String name, String introduction,
+                 ProcessingStatus processingStatus, Integer numberOfMaximumMember) {
         this.id = id;
         this.startAt = startAt;
         this.name = name;
         this.introduction = introduction;
-        this.periodOfRound = periodOfRound;
         this.processingStatus = processingStatus;
-        this.totalRoundCount = totalRoundCount;
         this.numberOfMaximumMember = numberOfMaximumMember;
     }
 
@@ -46,9 +42,7 @@ public enum StudyFixture {
                     .startAt(startAt)
                     .name(name)
                     .introduction(introduction)
-                    .periodOfRound(periodOfRound)
                     .processingStatus(processingStatus)
-                    .totalRoundCount(totalRoundCount)
                     .numberOfMaximumMembers(numberOfMaximumMember)
                     .rounds(List.of(아이디없는_라운드.toRound(), 아이디없는_라운드2.toRound(), 아이디없는_라운드3.toRound()))
                     .build();
@@ -64,9 +58,7 @@ public enum StudyFixture {
                     .startAt(startAt)
                     .name(name)
                     .introduction(introduction)
-                    .periodOfRound(periodOfRound)
                     .processingStatus(processingStatus)
-                    .totalRoundCount(totalRoundCount)
                     .numberOfMaximumMembers(numberOfMaximumMember)
                     .rounds(rounds)
                     .build();


### PR DESCRIPTION
## 😋 작업한 내용
새로운 피처를 개발하며 작성하는 테스트 코드를 실행해볼 수는 있어야 할 거 같아서 컴파일 에러에 대응했습니다. 깨지는 테스트를 돌아가도록 수정한 것이 아니라, 그저 컴파일이 가능하게끔만 했습니다. 자세한 내용은 다음 2가지입니다.
- Study 엔티티의 totalRoundCount, periodOfRound 필드를 제거하며 발생한 컴파일 에러 대응
- 해당 필드들이 제거되며 로직의 변화가 필요한 코드 수정 

## 🙏 PR Point
- 로직의 변화가 필요한 코드들에 대해서는 우선 컴파일이 되게끔만 했습니다. 즉 정상적인 로직이 아니라, 임시 해결한 로직입니다. 이에 대해서는 todo 주석 남겨놨으니 참고하시면 좋을 거 같습니다. 다음 3가지 메서드들입니다.
  - `Study.initializeRoundsEndAt()`
  - `StudyMember.completeSuccessfully()`
  - `StudyTest.스터디를_시작하면_라운드가_업데이트된다()`
- 기존의 Response DTO의 경우에도 그저 필드를 없애기만 했습니다. V2의 Response에 맞게 수정한 것이 아닙니다.

## 👍 관련 이슈

- Resolved : #469 
---

## 기획의 어떤 부분을 구현 / 수정했는가 (굉장히 상세하게 적어주세요, 해당 커밋의 링크, 코드의 위치를 남겨주면 더욱 좋습니다.)
기획과 직접적으로 관련된 수정은 아니라, 위에 설명한 내용을 참고하시면 좋을 거 같습니다.