### PR TITLE
[스플래시 뷰] 자동 로그인 수정

### DIFF
--- a/android/app/src/main/java/com/created/team201/data/datasource/local/DefaultTokenDataSource.kt
+++ b/android/app/src/main/java/com/created/team201/data/datasource/local/DefaultTokenDataSource.kt
@@ -10,11 +10,11 @@ class DefaultTokenDataSource @Inject constructor(
     }
 
     override fun getAccessToken(): String {
-        return tokenStorage.fetchToken(ACCESS_TOKEN) ?: throw IllegalStateException()
+        return tokenStorage.fetchToken(ACCESS_TOKEN)
     }
 
     override fun getRefreshToken(): String {
-        return tokenStorage.fetchToken(REFRESH_TOKEN) ?: throw IllegalStateException()
+        return tokenStorage.fetchToken(REFRESH_TOKEN)
     }
 
     override fun setAccessToken(token: String) {

--- a/android/app/src/main/java/com/created/team201/data/datasource/local/TokenStorage.kt
+++ b/android/app/src/main/java/com/created/team201/data/datasource/local/TokenStorage.kt
@@ -26,8 +26,8 @@ class TokenStorage @Inject constructor(context: Context) {
         editor.putString(key, value).apply()
     }
 
-    fun fetchToken(key: String): String? {
-        return storage.getString(key, null)
+    fun fetchToken(key: String): String {
+        return storage.getString(key, "") ?: ""
     }
 
     fun isGuest(key: String): Boolean {

--- a/android/app/src/main/java/com/created/team201/data/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/created/team201/data/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.created.domain.repository.AuthRepository
 import com.created.team201.BuildConfig.TEAM201_BASE_URL
 import com.created.team201.data.di.qualifier.AuthRetrofit
 import com.created.team201.data.di.qualifier.DefaultRetrofit
+import com.created.team201.data.remote.CallAdapterFactory
 import com.created.team201.data.remote.interceptor.AuthInterceptor
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
@@ -42,6 +43,7 @@ object NetworkModule {
     @DefaultRetrofit
     fun provideDefaultRetrofit(): Retrofit = Retrofit.Builder()
         .baseUrl(TEAM201_BASE_URL)
+        .addCallAdapterFactory(CallAdapterFactory())
         .addConverterFactory(Json.asConverterFactory(CONTENT_TYPE.toMediaType()))
         .build()
 

--- a/android/app/src/main/java/com/created/team201/data/remote/CallAdapterFactory.kt
+++ b/android/app/src/main/java/com/created/team201/data/remote/CallAdapterFactory.kt
@@ -1,0 +1,42 @@
+package com.created.team201.data.remote
+
+import com.created.domain.model.response.NetworkResponse
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class CallAdapterFactory : CallAdapter.Factory() {
+    override fun get(
+        returnType: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): CallAdapter<*, *>? {
+        if (Call::class.java != getRawType(returnType)) {
+            return null
+        }
+
+        check(returnType is ParameterizedType) {
+            ERROR_TYPE_HAS_NOT_GENERIC
+        }
+
+        val responseType = getParameterUpperBound(0, returnType)
+        if (getRawType(responseType) != NetworkResponse::class.java) {
+            return null
+        }
+
+        check(responseType is ParameterizedType) {
+            ERROR_TYPE_HAS_NOT_NETWORK_RESPONSE
+        }
+
+        val successBodyType = getParameterUpperBound(0, responseType)
+        return NetworkResponseCallAdapter<Any>(successBodyType)
+    }
+
+    companion object {
+        private const val ERROR_TYPE_HAS_NOT_GENERIC = "반환 타입은 제네릭 인자를 가져야 합니다"
+        private const val ERROR_TYPE_HAS_NOT_NETWORK_RESPONSE =
+            "반환 타입은 NetworkResponse를 제네릭 인자로 가져야 합니다"
+    }
+}

--- a/android/app/src/main/java/com/created/team201/data/remote/NetworkResponseCall.kt
+++ b/android/app/src/main/java/com/created/team201/data/remote/NetworkResponseCall.kt
@@ -1,0 +1,73 @@
+package com.created.team201.data.remote
+
+import com.created.domain.model.response.NetworkResponse
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.IOException
+
+class NetworkResponseCall<T : Any>(
+    private val call: Call<T>,
+) : Call<NetworkResponse<T>> {
+    override fun clone(): Call<NetworkResponse<T>> = NetworkResponseCall(call.clone())
+
+    override fun execute(): Response<NetworkResponse<T>> {
+        throw UnsupportedOperationException(ERROR_DO_NOT_SUPPORT_EXECUTE)
+    }
+
+    override fun enqueue(callback: Callback<NetworkResponse<T>>) {
+        call.enqueue(object : Callback<T> {
+            override fun onResponse(call: Call<T>, response: Response<T>) {
+                if (response.isSuccessful) {
+                    response.body()?.let { responseBody ->
+                        callback.onResponse(
+                            this@NetworkResponseCall,
+                            Response.success(NetworkResponse.Success(responseBody)),
+                        )
+                    } ?: run {
+                        @Suppress("UNCHECKED_CAST")
+                        callback.onResponse(
+                            this@NetworkResponseCall,
+                            Response.success(NetworkResponse.Success(Unit as T)),
+                        )
+                    }
+                } else {
+                    callback.onResponse(
+                        this@NetworkResponseCall,
+                        Response.success(
+                            NetworkResponse.Failure(
+                                response.code(),
+                                response.errorBody()?.string()
+                            ),
+                        ),
+                    )
+                }
+            }
+
+            override fun onFailure(call: Call<T>, t: Throwable) {
+                val response = when (t) {
+                    is IOException -> NetworkResponse.NetworkError(t)
+                    else -> NetworkResponse.Unexpected(t)
+                }
+                callback.onResponse(this@NetworkResponseCall, Response.success(response))
+            }
+        })
+    }
+
+    override fun isExecuted(): Boolean = call.isExecuted
+
+    override fun cancel() = call.cancel()
+
+
+    override fun isCanceled(): Boolean = call.isCanceled
+
+    override fun request(): Request = call.request()
+
+    override fun timeout(): Timeout = call.timeout()
+
+    companion object {
+        private const val ERROR_DO_NOT_SUPPORT_EXECUTE = "NetworkResponseCall은 execute를 지원하지 않습니다"
+    }
+}

--- a/android/app/src/main/java/com/created/team201/data/remote/NetworkResponseCall.kt
+++ b/android/app/src/main/java/com/created/team201/data/remote/NetworkResponseCall.kt
@@ -21,25 +21,19 @@ class NetworkResponseCall<T : Any>(
         call.enqueue(object : Callback<T> {
             override fun onResponse(call: Call<T>, response: Response<T>) {
                 if (response.isSuccessful) {
-                    response.body()?.let { responseBody ->
-                        callback.onResponse(
-                            this@NetworkResponseCall,
-                            Response.success(NetworkResponse.Success(responseBody)),
-                        )
-                    } ?: run {
-                        @Suppress("UNCHECKED_CAST")
-                        callback.onResponse(
-                            this@NetworkResponseCall,
-                            Response.success(NetworkResponse.Success(Unit as T)),
-                        )
-                    }
+                    @Suppress("UNCHECKED_CAST")
+                    val responseBody = response.body() ?: Unit as T
+                    callback.onResponse(
+                        this@NetworkResponseCall,
+                        Response.success(NetworkResponse.Success(responseBody)),
+                    )
                 } else {
                     callback.onResponse(
                         this@NetworkResponseCall,
                         Response.success(
                             NetworkResponse.Failure(
                                 response.code(),
-                                response.errorBody()?.string()
+                                response.errorBody()?.string(),
                             ),
                         ),
                     )

--- a/android/app/src/main/java/com/created/team201/data/remote/NetworkResponseCallAdapter.kt
+++ b/android/app/src/main/java/com/created/team201/data/remote/NetworkResponseCallAdapter.kt
@@ -1,0 +1,13 @@
+package com.created.team201.data.remote
+
+import com.created.domain.model.response.NetworkResponse
+import retrofit2.Call
+import retrofit2.CallAdapter
+import java.lang.reflect.Type
+
+class NetworkResponseCallAdapter<T : Any>(private val responseType: Type) :
+    CallAdapter<T, Call<NetworkResponse<T>>> {
+    override fun responseType(): Type = responseType
+
+    override fun adapt(call: Call<T>): Call<NetworkResponse<T>> = NetworkResponseCall(call)
+}

--- a/android/app/src/main/java/com/created/team201/data/remote/api/AuthService.kt
+++ b/android/app/src/main/java/com/created/team201/data/remote/api/AuthService.kt
@@ -1,5 +1,6 @@
 package com.created.team201.data.remote.api
 
+import com.created.domain.model.response.NetworkResponse
 import com.created.team201.data.remote.request.RenewedAccessTokenRequestDTO
 import com.created.team201.data.remote.response.AuthResponseDto
 import retrofit2.http.Body
@@ -18,10 +19,10 @@ interface AuthService {
     @POST("v1/login/tokens/refresh")
     suspend fun postRenewedAccessToken(
         @Body refreshToken: RenewedAccessTokenRequestDTO,
-    ): AuthResponseDto
+    ): NetworkResponse<AuthResponseDto>
 
     @GET("v1/login/tokens/validate")
     suspend fun getLoginValidity(
         @Header("Authorization") accessToken: String,
-    )
+    ): NetworkResponse<Unit>
 }

--- a/android/app/src/main/java/com/created/team201/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/created/team201/data/repository/DefaultAuthRepository.kt
@@ -1,5 +1,6 @@
 package com.created.team201.data.repository
 
+import com.created.domain.model.response.NetworkResponse
 import com.created.domain.repository.AuthRepository
 import com.created.team201.data.datasource.local.TokenDataSource
 import com.created.team201.data.remote.api.AuthService
@@ -13,7 +14,6 @@ class DefaultAuthRepository @Inject constructor(
     override val accessToken get() = tokenDataSource.getAccessToken()
     override val refreshToken get() = tokenDataSource.getRefreshToken()
 
-
     override suspend fun requestSignUp(token: String): Result<Unit> {
         return runCatching {
             val tokens = authService.getTokens(token)
@@ -22,23 +22,27 @@ class DefaultAuthRepository @Inject constructor(
         }
     }
 
-    override suspend fun requestSignIn(): Result<Unit> {
-        return runCatching {
-            authService.getLoginValidity(accessToken)
-        }
+    override suspend fun requestSignIn(): NetworkResponse<Unit> {
+        return authService.getLoginValidity(accessToken)
     }
 
-    override suspend fun renewAccessToken() {
-        runCatching {
-            authService.postRenewedAccessToken(
-                RenewedAccessTokenRequestDTO(
-                    refreshToken
-                )
+    override suspend fun renewAccessToken(): NetworkResponse<Unit> {
+        val response = authService.postRenewedAccessToken(
+            RenewedAccessTokenRequestDTO(
+                refreshToken
             )
-        }.onSuccess { tokens ->
-            tokenDataSource.setAccessToken(tokens.accessToken)
-            tokenDataSource.setRefreshToken(tokens.refreshToken)
-        }.onFailure {
+        )
+        return when (response) {
+            is NetworkResponse.Success -> {
+                val tokens = response.body
+                tokenDataSource.setAccessToken(tokens.accessToken)
+                tokenDataSource.setRefreshToken(tokens.refreshToken)
+                NetworkResponse.Success(Unit)
+            }
+
+            is NetworkResponse.Failure -> response
+            is NetworkResponse.NetworkError -> response
+            is NetworkResponse.Unexpected -> response
         }
     }
 }

--- a/android/app/src/main/java/com/created/team201/data/repository/DefaultGuestRepository.kt
+++ b/android/app/src/main/java/com/created/team201/data/repository/DefaultGuestRepository.kt
@@ -1,15 +1,18 @@
 package com.created.team201.data.repository
 
 import com.created.domain.repository.GuestRepository
+import com.created.team201.data.datasource.local.OnBoardingDataSource
 import com.created.team201.data.datasource.local.TokenDataSource
 import javax.inject.Inject
 
 class DefaultGuestRepository @Inject constructor(
     private val tokenDataSource: TokenDataSource,
+    private val onBoardingDataSource: OnBoardingDataSource,
 ) : GuestRepository {
     override fun signUpGuest() {
         tokenDataSource.setAccessToken("")
         tokenDataSource.setRefreshToken("")
+        onBoardingDataSource.setOnBoardingIsDone(false)
     }
 
     override fun getIsGuest(): Boolean {

--- a/android/app/src/main/java/com/created/team201/data/repository/DefaultSettingRepository.kt
+++ b/android/app/src/main/java/com/created/team201/data/repository/DefaultSettingRepository.kt
@@ -13,12 +13,15 @@ class DefaultSettingRepository @Inject constructor(
 ) : SettingRepository {
     override fun logout() {
         tokenDataSource.setAccessToken("")
+        tokenDataSource.setRefreshToken("")
+        onBoardingDataSource.setOnBoardingIsDone(false)
     }
 
     override suspend fun requestWithdrawAccount(): Result<Unit> {
         return runCatching {
             settingService.requestWithdrawAccount()
             tokenDataSource.setAccessToken("")
+            tokenDataSource.setRefreshToken("")
             onBoardingDataSource.setOnBoardingIsDone(false)
         }
     }

--- a/android/app/src/main/java/com/created/team201/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/splash/SplashActivity.kt
@@ -43,11 +43,10 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
         splashViewModel.onBoardingDoneState.observe(this@SplashActivity) { onBoardingState ->
             when (onBoardingState) {
                 is OnBoardingDoneState.Success -> {
-                    if (onBoardingState.isDone) {
-                        navigateToMain()
-                        return@observe
+                    when (onBoardingState.isDone) {
+                        true -> navigateToMain()
+                        false -> navigateToLogin()
                     }
-                    navigateToLogin()
                 }
 
                 OnBoardingDoneState.FAIL -> navigateToLogin()

--- a/android/domain/src/main/java/com/created/domain/model/response/NetworkResponse.kt
+++ b/android/domain/src/main/java/com/created/domain/model/response/NetworkResponse.kt
@@ -1,0 +1,10 @@
+package com.created.domain.model.response
+
+import java.io.IOException
+
+sealed class NetworkResponse<out T : Any> {
+    data class Success<T : Any>(val body: T) : NetworkResponse<T>()
+    data class Failure(val responseCode: Int, val error: String?) : NetworkResponse<Nothing>()
+    data class NetworkError(val exception: IOException) : NetworkResponse<Nothing>()
+    data class Unexpected(val t: Throwable?) : NetworkResponse<Nothing>()
+}

--- a/android/domain/src/main/java/com/created/domain/repository/AuthRepository.kt
+++ b/android/domain/src/main/java/com/created/domain/repository/AuthRepository.kt
@@ -1,5 +1,7 @@
 package com.created.domain.repository
 
+import com.created.domain.model.response.NetworkResponse
+
 interface AuthRepository {
 
     val accessToken: String
@@ -7,7 +9,7 @@ interface AuthRepository {
 
     suspend fun requestSignUp(token: String): Result<Unit>
 
-    suspend fun requestSignIn(): Result<Unit>
+    suspend fun requestSignIn(): NetworkResponse<Unit>
 
-    suspend fun renewAccessToken()
+    suspend fun renewAccessToken(): NetworkResponse<Unit>
 }


### PR DESCRIPTION
## 😋 작업한 내용
- AuthRepository CallAdpater 도입
- 로그아웃 및 게스트 로그인 시 OnBoarding 완료 여부 초기화

## 🙏 PR Point
- CallAdapter를 모든 곳에서 사용하도록 리펙터링 하면 이점이 극대화 될 거 같지만, 아직 콜어댑터에 대한 이해도와 팀원의 합의가 완전히 이뤄지지 않아 AuthRepository에만 적용해놨습니다.

- 기존에는 ReNewAccessToken()의 반환값이 Unit이라 갱신 후에 재 토큰 검증을 해야 로그인 성공, 실패 여부를 반환할 수 있었는데, 생각해보니 토큰 갱신을 성공했다는것 조차 이미 로그인이 성공했다는 의미로 볼 수 있어 기존 Unit을 반환하던 함수를 NetworkResponse<Unit>을 반환하도록 수정하였습니다.
> 이에 2차 검증을 수행하는 것이 더 바람직하지 않나? 라는 생각이 드신다면 의견 공유 바랍니다.

## 👍 관련 이슈

- Resolved : #472 

