### PR TITLE
feat: 스터디 종료 기능 추가

### DIFF
--- a/backend/src/main/java/com/yigongil/backend/application/StudyService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/StudyService.java
@@ -277,14 +277,22 @@ public class StudyService {
         return MembersCertificationResponse.of(study.getName(), member, roundOfMembers);
     }
 
+    @Transactional(readOnly = true)
     public CertificationResponse findCertification(Long certificationId) {
         return CertificationResponse.from(certificationService.findById(certificationId));
     }
 
+    @Transactional(readOnly = true)
     public List<FeedPostResponse> findFeedPosts(Long id, Long oldestFeedPostId) {
         return feedService.findFeedPosts(id, oldestFeedPostId)
                           .stream()
                           .map(FeedPostResponse::from)
                           .toList();
+    }
+
+    @Transactional
+    public void finish(Member member, Long studyId) {
+        Study study = findStudyById(studyId);
+        study.finishStudy(member);
     }
 }

--- a/backend/src/main/java/com/yigongil/backend/domain/round/Round.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/round/Round.java
@@ -219,6 +219,10 @@ public class Round extends BaseEntity {
         return meetingDayOfTheWeek.getDayOfWeek();
     }
 
+    public boolean isBeforeOrSame(Integer minimumWeeks) {
+        return weekNumber <= minimumWeeks;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
@@ -9,6 +9,7 @@ import com.yigongil.backend.domain.studymember.Role;
 import com.yigongil.backend.domain.studymember.StudyMember;
 import com.yigongil.backend.domain.studymember.StudyResult;
 import com.yigongil.backend.exception.ApplicantAlreadyExistException;
+import com.yigongil.backend.exception.CannotEndException;
 import com.yigongil.backend.exception.CannotStartException;
 import com.yigongil.backend.exception.InvalidMemberSizeException;
 import com.yigongil.backend.exception.InvalidNumberOfMaximumStudyMember;
@@ -141,14 +142,14 @@ public class Study extends BaseEntity {
             Member master
     ) {
         return Study.builder()
-                           .name(name)
-                           .numberOfMaximumMembers(numberOfMaximumMembers)
-                           .meetingDaysCountPerWeek(meetingDaysCountPerWeek)
-                           .minimumWeeks(minimumWeeks)
-                           .introduction(introduction)
-                           .processingStatus(ProcessingStatus.RECRUITING)
-                           .master(master)
-                           .build();
+                    .name(name)
+                    .numberOfMaximumMembers(numberOfMaximumMembers)
+                    .meetingDaysCountPerWeek(meetingDaysCountPerWeek)
+                    .minimumWeeks(minimumWeeks)
+                    .introduction(introduction)
+                    .processingStatus(ProcessingStatus.RECRUITING)
+                    .master(master)
+                    .build();
     }
 
     private void validateNumberOfMaximumMembers(Integer numberOfMaximumMembers) {
@@ -294,8 +295,18 @@ public class Study extends BaseEntity {
 
     public void finishStudy(Member master) {
         validateMaster(master);
+        validateStudyCanFinish();
         studyMembers.forEach(StudyMember::completeSuccessfully);
         this.processingStatus = ProcessingStatus.END;
+    }
+
+    private void validateStudyCanFinish() {
+        if (isEnd()) {
+            throw new CannotEndException("이미 종료된 스터디입니다.", String.valueOf(id));
+        }
+        if (getCurrentRound().isBeforeOrSame(minimumWeeks)) {
+            throw new CannotEndException("최소 진행 주차를 채우지 못했습니다.", String.valueOf(id));
+        }
     }
 
     public Member getMaster() {

--- a/backend/src/main/java/com/yigongil/backend/exception/CannotEndException.java
+++ b/backend/src/main/java/com/yigongil/backend/exception/CannotEndException.java
@@ -1,0 +1,10 @@
+package com.yigongil.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CannotEndException extends HttpException {
+
+    public CannotEndException(String message, String input) {
+        super(HttpStatus.BAD_REQUEST, message, input);
+    }
+}

--- a/backend/src/main/java/com/yigongil/backend/ui/StudyController.java
+++ b/backend/src/main/java/com/yigongil/backend/ui/StudyController.java
@@ -189,5 +189,14 @@ public class StudyController implements StudyApi {
         StudyMemberRoleResponse response = studyService.getMemberRoleOfStudy(member, studyId);
         return ResponseEntity.ok(response);
     }
+
+    @PatchMapping("/{studyId}/end")
+    public ResponseEntity<Void> endStudy(
+            @Authorization Member member,
+            @PathVariable Long studyId
+    ) {
+        studyService.finish(member, studyId);
+        return ResponseEntity.ok().build();
+    }
 }
 


### PR DESCRIPTION
## 😋 작업한 내용

스터디 종료 api를 통해 종료하도록 만들었습니다

마스터가 아닐 경우, 기존 종료 상태일 경우, 최소주차를 채우지 못했을 경우 예외 발생합니다

테스트는 내일 추가할게요

## 🙏 PR Point

- 

## 👍 관련 이슈

- Resolved : #483


---

## 기획의 어떤 부분을 구현 / 수정했는가 (굉장히 상세하게 적어주세요, 해당 커밋의 링크, 코드의 위치를 남겨주면 더욱 좋습니다.)

밑은 예시입니다.

**[시작되면서 스터디의 주 몇 회 정보를 유저가 실제로 선택한 일 수로 수정](http://관련기획링크)**
  - StudyService의 createStudy 메서드에서 PeriodOfRound 를 받지 않도록 수정했습니다. [해당커밋](http://커밋링크)
  - Study의 start 메서드에서 파라미터로 시작한 날짜를 받도록 구현하였습니다.
  - 날짜(월화수목금토일)를 뜻하는 Enum을 Study 패키지에 추가하였습니다.
  - flyway에서 해당 엔티티에 필요할 칼럼을 수정했습니다.

**[스터디가 더 이상 종료되지 않도록 수정](http://관련기획링크)**
  - 상동 
