### PR TITLE
[마이페이지 뷰] 티어 경험치 표시 뷰를 서버연동 합니다.

### DIFF
--- a/android/app/src/main/java/com/created/team201/presentation/myPage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/myPage/MyPageFragment.kt
@@ -52,10 +52,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         setNicknameValidate()
         setMyPageObserve()
         setOnProfileModifyClick()
-
-        // ToDo: 아래는 서버 연결시 변경됩니다.
-        val tierProgress = TierProgress.of(Tier.DIAMOND, 57).getTierProgressTable()
-        setupTierProgress(tierProgress)
+        observeProfile()
     }
 
     private fun initBinding() {
@@ -195,7 +192,16 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         }
     }
 
+    private fun observeProfile() {
+        myPageViewModel.profile.observe(viewLifecycleOwner) { profile ->
+            val tierProgress =
+                TierProgress.of(Tier.of(profile.tier), profile.tierProgress).getTierProgressTable()
+            setupTierProgress(tierProgress)
+        }
+    }
+
     private fun setupTierProgress(tierProgress: List<Int>) {
+        binding.glMyPageTierProgress.removeAllViews()
         repeat(TOTAL_BLOCK_COUNT) {
             val params: GridLayout.LayoutParams = getDefaultTierProgressBlockParams()
 

--- a/android/app/src/main/java/com/created/team201/presentation/myPage/MyPageViewModel.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/myPage/MyPageViewModel.kt
@@ -88,7 +88,7 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             profile.value?.let {
                 val newProfile = it.toDomain().updateProfileInformation(
-                    ProfileInformation(nickname.value.toDomain(), introduction.value)
+                    ProfileInformation(nickname.value.toDomain(), introduction.value),
                 )
                 myPageRepository.patchMyProfile(newProfile.profileInformation)
                     .onSuccess {
@@ -100,7 +100,6 @@ class MyPageViewModel @Inject constructor(
                     }.onFailure {
                         _modifyProfileState.value = State.FAIL
                     }
-
             }
         }
     }
@@ -218,11 +217,11 @@ class MyPageViewModel @Inject constructor(
     private fun ProfileInformation.toUiModel(): ProfileInformationUiModel =
         ProfileInformationUiModel(
             nickname = nickname.toUiModel(),
-            introduction = introduction
+            introduction = introduction,
         )
 
     private fun Nickname.toUiModel(): NicknameUiModel = NicknameUiModel(
-        nickname = nickname
+        nickname = nickname,
     )
 
     private fun ProfileUiModel.toDomain(): Profile = Profile(
@@ -239,11 +238,11 @@ class MyPageViewModel @Inject constructor(
     private fun ProfileInformationUiModel.toDomain(): ProfileInformation =
         ProfileInformation(
             nickname = nickname.toDomain(),
-            introduction = introduction
+            introduction = introduction,
         )
 
     private fun NicknameUiModel.toDomain(): Nickname = Nickname(
-        nickname = nickname
+        nickname = nickname,
     )
 
     companion object {

--- a/android/app/src/main/java/com/created/team201/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/created/team201/presentation/splash/SplashViewModel.kt
@@ -32,10 +32,9 @@ class SplashViewModel @Inject constructor(
     private val _onBoardingDoneState: MutableLiveData<OnBoardingDoneState> = MutableLiveData()
     val onBoardingDoneState: LiveData<OnBoardingDoneState> get() = _onBoardingDoneState
 
-
     fun getAppUpdateInformation(versionCode: Int) {
         splashRepository.getAppUpdateInformation(versionCode) { appUpdateInformation ->
-            _appUpdateInformation.value = appUpdateInformation
+            _appUpdateInformation.postValue(appUpdateInformation)
         }
     }
 


### PR DESCRIPTION
## 😋 작업한 내용

-  티어 경험치 표시 뷰를 서버연동 합니다.

## 🙏 PR Point

- 그동안 마이페이지에서 뷰모델의 라이브데이터를 xml에서만 참조를 했는데, 동적으로 뷰를 만들어주기 위해서 진짜 구슬프게도 mypage fragment에서 `profileUiModel`를 observe 하는 로직을 작성하였습니다.
- 후에 아키텍처 관련 리팩터링이 있을 경우 같이 수정하면 좋을 것 같습니다.
- 현재 경험치를 단 하나도 받은 유저가 하나도 없어서 실존 서버데이터로 테스트하지 못하였습니다. ㅜㅠ
## 👍 관련 이슈

- Resolved : #512 
