### PR TITLE
hotfix: 스터디 멤버 삭제 로직을 study 안으로 이관

### DIFF
--- a/backend/src/main/java/com/yigongil/backend/application/StudyService.java
+++ b/backend/src/main/java/com/yigongil/backend/application/StudyService.java
@@ -220,15 +220,10 @@ public class StudyService {
 
     @Transactional
     public void start(Member member, Long studyId, StudyStartRequest request) {
-        deleteLeftApplicants(studyId);
         List<DayOfWeek> meetingDaysOfTheWeek = createDayOfWeek(request.meetingDaysOfTheWeek());
 
         Study study = findStudyById(studyId);
         study.start(member, meetingDaysOfTheWeek, LocalDateTime.now());
-    }
-
-    private void deleteLeftApplicants(final Long studyId) {
-        studyMemberRepository.deleteAllByStudyIdAndRole(studyId, Role.APPLICANT);
     }
 
     private List<DayOfWeek> createDayOfWeek(List<String> daysOfTheWeek) {

--- a/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/study/Study.java
@@ -218,9 +218,17 @@ public class Study extends BaseEntity {
         if (sizeOfCurrentMembers() == ONE_MEMBER) {
             throw new CannotStartException("스터디의 멤버가 한 명일 때는 시작할 수 없습니다.", id);
         }
+        deleteLeftApplicant();
+
         this.processingStatus = ProcessingStatus.PROCESSING;
         initializeMeetingDaysOfTheWeek(daysOfTheWeek);
         initializeRounds(startAt.toLocalDate());
+    }
+
+    private void deleteLeftApplicant() {
+        studyMembers.stream()
+                    .filter(StudyMember::isApplicant)
+                    .forEach(studyMember -> studyMembers.remove(studyMember));
     }
 
     private void initializeMeetingDaysOfTheWeek(List<DayOfWeek> daysOfTheWeek) {

--- a/backend/src/main/java/com/yigongil/backend/domain/studymember/StudyMember.java
+++ b/backend/src/main/java/com/yigongil/backend/domain/studymember/StudyMember.java
@@ -76,6 +76,10 @@ public class StudyMember extends BaseEntity {
         return this.role == Role.STUDY_MEMBER || isMaster();
     }
 
+    public boolean isApplicant() {
+        return this.role == Role.APPLICANT;
+    }
+
     public boolean isMaster() {
         return this.role == Role.MASTER;
     }


### PR DESCRIPTION
## 😋 작업한 내용

- 스터디 양방향 참조로 인해 발생하는 중복 지원자 문제 해결
- service에서 repository를 이용해 직접적으로 삭제된 지원자가 스터디가 플러쉬 될 때 cascade, persiste로 인해 다시 부활하는 문제를 해결했습니다.
